### PR TITLE
make sure rownames(meta) == colnames(counts) in DESeq2

### DIFF
--- a/src/deseq2.R
+++ b/src/deseq2.R
@@ -51,6 +51,11 @@ meta <- read.csv(meta, header = T, stringsAsFactors = F)
 # make the meta reflect the available sample names
 meta = meta[meta$sample %in% colnames(counts),]
 
+# make sure meta rownames and counts colnames in the same order.
+rownames(meta) <- meta$sample
+counts <- counts[, rownames(meta)]
+stopifnot(rownames(meta) == colnames(counts))
+
 message('calculating deseq...')
 print(head(counts))
 print(head(meta))


### PR DESCRIPTION
With the new code snippet, the order of contrasts will affect the results. 
Without the new code snippet, you can switch the order of conditions in the src/deseq2_metadata.csv file yet nothing will change compared to running DE using the an unedited version the deseq2 meta csv file. 

For example when there's 2 conditions, **cond1-cond2-up-01.bed** will normally show upregulated peaks in cond1.
If you switch the order of conditions in the src/deseq2_metadata.csv, the **cond2-cond1-up-01.bed** file will still show upregulated peaks in cond1.
Once the order of meta row names matches count's column names, the second example above will show upregulated peaks in cond2.
I only run this in 2 conditions, so unsure how it will behave with more. 

source: https://www.bioconductor.org/packages/devel/bioc/vignettes/DESeq2/inst/doc/DESeq2.html#count-matrix-input