### PR TITLE
Modified rule frip to handle empty input bed files, i.e. when no peak…

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -40,7 +40,9 @@ marks_noigg = [m for m in marks if config["IGG"] not in m]
 
 localrules: frip_plot, fraglength_plot
 
-singularity: "library://gartician/miniconda-mamba/4.12.0:sha256.7302640e37d37af02dd48c812ddf9c540a7dfdbfc6420468923943651f795591"
+#singularity: "library://gartician/miniconda-mamba/4.12.0:sha256.7302640e37d37af02dd48c812ddf9c540a7dfdbfc6420468923943651f795591"
+singularity: "/home/groups/MaxsonLab/software/singularity-containers/4.12.0_sha256.7302640e37d37af02dd48c812ddf9c540a7dfdbfc6420468923943651f795591.sif"
+
 
 rule all:
     input:
@@ -307,7 +309,7 @@ rule frip:
     log:
         "data/logs/plotEnrichment_{sample}.log"
     shell:
-        "plotEnrichment -b {input[1]} --BED {input[0]} --regionLabels 'frip' --outRawCounts {output[1]} -o {output[0]} > {log} 2>&1"
+        "bash src/skip_frip.sh {input[0]} {input[1]} {output[0]} {output[1]}"
 
 rule frip_plot:
     input:

--- a/envs/dtools.yml
+++ b/envs/dtools.yml
@@ -67,6 +67,7 @@ dependencies:
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python_abi=3.7=2_cp37m
   - readline=8.1.2=h0f457ee_0
+  - samtools
   - scipy=1.7.3=py37hf2a6cf1_0
   - setuptools=65.5.1=pyhd8ed1ab_0
   - six=1.16.0=pyh6c4a22f_0

--- a/src/skip_frip.sh
+++ b/src/skip_frip.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# For samples with peak calls (i.e. bed files with content), perform frip step as normal.
+# For samples with no peak calls (i.e. empty bed files), skip frip and just create frip output file with 0 counts.
+
+INPUT0=$1
+INPUT1=$2
+OUTPUT0=$3
+OUTPUT1=$4
+
+if [ -s ${INPUT0} ]
+then
+	plotEnrichment -b ${INPUT1} --BED ${INPUT0} --regionLabels 'frip' --outRawCounts ${OUTPUT1} -o ${OUTPUT0} > {log} 2>&1
+else
+	total_read_count=$(samtools view ${INPUT1} | wc -l)
+	echo "file	featureType	percent	featureReadCount	totalReadCount" > ${OUTPUT1} #creates output file with column headers
+	echo "${INPUT1}	frip	0	0	${total_read_count}" >> ${OUTPUT1} #appends to existing output file with name of sample and 0 counts
+	touch ${OUTPUT0}
+fi


### PR DESCRIPTION
…s are called for a sample. Modified dtools.yml to include samtools and commented out all other dependencies so that most recent packages would be used. Modified Snakefile rule frip accordingly. Added skip_frip.sh to src folder.